### PR TITLE
fix: acorn parser crash on CSS files

### DIFF
--- a/vite-plugin-cjs-interop/src/index.test.ts
+++ b/vite-plugin-cjs-interop/src/index.test.ts
@@ -90,3 +90,15 @@ import { __cjs_dyn_import__ } from "virtual:cjs-dyn-import";
 		// Use barDefault and barNamed here
 	});
 `;
+
+const CSS_INPUT = `:root{--mantine-font-family: Open Sans, sans-serif;`;
+
+test("ingnors css code", async () => {
+	const plugin = cjsInterop({ dependencies: ["foo"] });
+
+	const output = await (plugin.transform as any)!(CSS_INPUT, "x.css", {
+		ssr: true,
+	});
+
+	expect(output).toBeUndefined();
+});

--- a/vite-plugin-cjs-interop/src/index.test.ts
+++ b/vite-plugin-cjs-interop/src/index.test.ts
@@ -93,7 +93,7 @@ import { __cjs_dyn_import__ } from "virtual:cjs-dyn-import";
 
 const CSS_INPUT = `:root{--mantine-font-family: Open Sans, sans-serif;`;
 
-test("ingnors css code", async () => {
+test("ignore css assets", async () => {
 	const plugin = cjsInterop({ dependencies: ["foo"] });
 
 	const output = await (plugin.transform as any)!(CSS_INPUT, "x.css", {

--- a/vite-plugin-cjs-interop/src/index.ts
+++ b/vite-plugin-cjs-interop/src/index.ts
@@ -27,6 +27,9 @@ export interface CjsInteropOptions {
 	apply?: "build" | "serve" | "both";
 }
 
+const CSS_LANGS_RE =
+	/\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/;
+
 export function cjsInterop(options: CjsInteropOptions): Plugin {
 	const virtualModuleId = "virtual:cjs-dyn-import";
 	const dependencies = Array.from(new Set(options.dependencies));
@@ -47,7 +50,7 @@ export function cjsInterop(options: CjsInteropOptions): Plugin {
 
 		async transform(code, id, options) {
 			if (!client && !options?.ssr) return;
-			if (id.endsWith(".css")) return;
+			if (CSS_LANGS_RE.test(id)) return;
 
 			const ast = Parser.parse(code, {
 				sourceType: "module",

--- a/vite-plugin-cjs-interop/src/index.ts
+++ b/vite-plugin-cjs-interop/src/index.ts
@@ -47,6 +47,7 @@ export function cjsInterop(options: CjsInteropOptions): Plugin {
 
 		async transform(code, id, options) {
 			if (!client && !options?.ssr) return;
+			if (id.endsWith(".css")) return;
 
 			const ast = Parser.parse(code, {
 				sourceType: "module",


### PR DESCRIPTION
This is a fix for #29. The plugin will ignore files ending with `.css`