### PR TITLE
feat: auto-detect hoisting bug

### DIFF
--- a/tests/bench/vite.config.client.ts
+++ b/tests/bench/vite.config.client.ts
@@ -9,7 +9,6 @@ export default defineConfig({
 	},
 	plugins: [
 		cjsInterop({
-			trustViteWithHoisting: false,
 			client: true,
 			dependencies: [
 				"cjs-test-package",

--- a/vite-plugin-cjs-interop/src/index.test.ts
+++ b/vite-plugin-cjs-interop/src/index.test.ts
@@ -24,6 +24,15 @@ async function callTransform(
 		return code;
 	}
 
+	await (plugin.configResolved as any)?.call(
+		{ meta: { viteVersion: "8.0.6" } },
+		{
+			build: {
+				sourcemap: false,
+			},
+		} as any,
+	);
+
 	const result = await tr.handler.call(null as any, code, id, {
 		ssr: true,
 		moduleType: "js",

--- a/vite-plugin-cjs-interop/src/index.ts
+++ b/vite-plugin-cjs-interop/src/index.ts
@@ -28,6 +28,11 @@ export interface CjsInteropOptions {
 	/**
 	 * Set to false for to workaround https://github.com/vitejs/vite/issues/22122.
 	 *
+	 * @deprecated Vite 8.0.6 fixed the issue. The plugin will automatically
+	 * detect if the Vite version is affected and apply the workaround if
+	 * necessary. Providing it manually will still override the automatic
+	 * detection but is now unnecessary and will be removed in the near future.
+	 *
 	 * @default true
 	 */
 	trustViteWithHoisting?: boolean;
@@ -41,8 +46,11 @@ export function cjsInterop(options: CjsInteropOptions): Plugin {
 	const {
 		client = false,
 		apply = "both",
-		trustViteWithHoisting = true,
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
+		trustViteWithHoisting: trustViteWithHoistingOption,
 	} = options;
+
+	let trustViteWithHoisting = trustViteWithHoistingOption;
 
 	let sourcemaps = false;
 
@@ -80,6 +88,13 @@ export function cjsInterop(options: CjsInteropOptions): Plugin {
 
 		configResolved(config) {
 			sourcemaps = !!config.build.sourcemap;
+
+			if (trustViteWithHoistingOption === undefined) {
+				const [major, minor, patch] = this.meta.viteVersion
+					.split(".")
+					.map(Number) as [number, number, number];
+				trustViteWithHoisting = !(major === 8 && minor === 0 && patch <= 5);
+			}
 		},
 
 		transform: {


### PR DESCRIPTION
This PR deprecates the `trustViteWithHoisting` option and will now autodetect if the Vite version requires the workaround for #100 caused by https://github.com/vitejs/vite/issues/22122.

The issue was fixed upstream in Vite 8.0.6. The plugin will now check the Vite version and work around for it if the version is between 8.0.0 and 8.0.5 (inclusive).