### PR TITLE
fix: read vite version from exported constant in configResolved

### DIFF
--- a/vite-plugin-cjs-interop/src/index.test.ts
+++ b/vite-plugin-cjs-interop/src/index.test.ts
@@ -24,14 +24,11 @@ async function callTransform(
 		return code;
 	}
 
-	await (plugin.configResolved as any)?.call(
-		{ meta: { viteVersion: "8.0.6" } },
-		{
-			build: {
-				sourcemap: false,
-			},
-		} as any,
-	);
+	await (plugin.configResolved as any)?.call({}, {
+		build: {
+			sourcemap: false,
+		},
+	} as any);
 
 	const result = await tr.handler.call(null as any, code, id, {
 		ssr: true,

--- a/vite-plugin-cjs-interop/src/index.ts
+++ b/vite-plugin-cjs-interop/src/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "vite";
+import { version as viteVersion, type Plugin } from "vite";
 import { parse } from "oxc-parser";
 import MagicString from "magic-string";
 import { minimatch } from "minimatch";
@@ -90,9 +90,11 @@ export function cjsInterop(options: CjsInteropOptions): Plugin {
 			sourcemaps = !!config.build.sourcemap;
 
 			if (trustViteWithHoistingOption === undefined) {
-				const [major, minor, patch] = this.meta.viteVersion
-					.split(".")
-					.map(Number) as [number, number, number];
+				const [major, minor, patch] = viteVersion.split(".").map(Number) as [
+					number,
+					number,
+					number,
+				];
 				trustViteWithHoisting = !(major === 8 && minor === 0 && patch <= 5);
 			}
 		},


### PR DESCRIPTION
Fixes #107.

`this.meta` is not always defined on the plugin context inside the `configResolved` hook (notably in Vite 5), so accessing `this.meta.viteVersion` crashes with `TypeError: Cannot read properties of undefined (reading 'meta')` when the new auto-detect hoisting logic from #103 runs during a build.

Vite re-exports the resolved package version as `version`, so importing it directly works across all supported Vite versions without depending on a hook-specific context shape.

The test mock for `configResolved` is updated since it no longer needs to stand in for `this.meta`.