### PR TITLE
Add package support metadata

### DIFF
--- a/packages/vite-plugin-cjs-interop/package.json
+++ b/packages/vite-plugin-cjs-interop/package.json
@@ -10,6 +10,10 @@
   ],
   "license": "MIT",
   "repository": "github:cyco130/vite-plugin-cjs-interop",
+  "homepage": "https://github.com/cyco130/vite-plugin-cjs-interop#readme",
+  "bugs": {
+    "url": "https://github.com/cyco130/vite-plugin-cjs-interop/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

Add standard npm package support metadata to `vite-plugin-cjs-interop`:

- `homepage` points to the project README
- `bugs.url` points to the GitHub issue tracker

## Verification

```bash
node - <<'NODE'
const fs = require('fs')
const pkg = JSON.parse(fs.readFileSync('packages/vite-plugin-cjs-interop/package.json', 'utf8'))
if (pkg.homepage !== 'https://github.com/cyco130/vite-plugin-cjs-interop#readme') process.exit(1)
if (pkg.bugs?.url !== 'https://github.com/cyco130/vite-plugin-cjs-interop/issues') process.exit(1)
console.log('metadata ok')
NODE
npm pack --dry-run --ignore-scripts ./packages/vite-plugin-cjs-interop
git diff --check
```

Related metadata bounty: charles-openclaw/charles-microbounties#643